### PR TITLE
Update README.md: pip install ipython as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ machine with Cuda 12.1:
 python -m venv multid
 pip install -r requirements.txt 
 OR
-pip install transformer_lens sae_lens transformers datasets torch adjustText circuitsvis
+pip install transformer_lens sae_lens transformers datasets torch adjustText circuitsvis ipython
 ```
 Let us know if anything does not work with this environment!
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below are instructions to reproduce each figure (aspirationally).
 
 The required pthon packages to run this repo are
 ```
-transformer_lens sae_lens transformers datasets torch adjustText circuitsvis
+transformer_lens sae_lens transformers datasets torch adjustText circuitsvis ipython
 ```
 We recommend you creat a new python venv named multid and install these packages,
 either manually using pip or using the existing requirements.txt if you are on a linux


### PR DESCRIPTION
Otherwise
```
python circle_probe_interventions.py day a mistral --device 0 --intervention_pca_k 5 --probe_on_cos --probe_on_sin
```
gives
```
Traceback (most recent call last):
  File "/path/to/MultiDimensionalFeatures/intervention/circle_probe_interventions.py", line 24, in <module>
    if not is_notebook():
           ^^^^^^^^^^^^^
  File "/path/to/MultiDimensionalFeatures/intervention/utils.py", line 40, in is_notebook
    from IPython import get_ipython
ModuleNotFoundError: No module named 'IPython'
```