### PR TITLE
Revert to cpu if cuda is not available (backwards compatible version)

### DIFF
--- a/intervention/circle_probe_interventions.py
+++ b/intervention/circle_probe_interventions.py
@@ -41,7 +41,7 @@ if not is_notebook():
         choices=["llama", "mistral"],
         help="Choose 'llama' or 'mistral' model",
     )
-    parser.add_argument("--device", type=int, default=4, help="CUDA device number")
+    parser.add_argument("--device", type=str, default="4", help="CUDA device number, or full device string")
     parser.add_argument(
         "--use_inverse_regression_probe",
         action="store_true",
@@ -73,7 +73,7 @@ if not is_notebook():
         help="Probe on linear representation with center of 0.",
     )
     args = parser.parse_args()
-    device = f"cuda:{args.device}"
+    device = (f"cuda:{args.device}" if torch.cuda.is_available() else "cpu") if args.device.isnumeric() else args.device
     day_month_choice = args.problem_type
     circle_letter = args.intervene_on
     model_name = args.model
@@ -100,7 +100,7 @@ else:
     # use_inverse_regression_probe = False
     # intervention_pca_k = 5
 
-    device = "cuda:4"
+    device = "cuda:4" if torch.cuda.is_available() else "cpu"
     circle_letter = "c"
     day_month_choice = "day"
     model_name = "mistral"

--- a/intervention/days_of_week_task.py
+++ b/intervention/days_of_week_task.py
@@ -11,7 +11,7 @@ from task import Problem, get_acts, plot_pca, get_all_acts, get_acts_pca
 from task import activation_patching
 
 
-device = "cuda:4"
+device = "cuda:4" if torch.cuda.is_available() else "cpu"
 #
 # %%
 

--- a/intervention/months_of_year_task.py
+++ b/intervention/months_of_year_task.py
@@ -5,13 +5,14 @@ from utils import setup_notebook, BASE_DIR
 
 setup_notebook()
 
+import torch
 import numpy as np
 import transformer_lens
 from task import Problem, get_acts, plot_pca, get_all_acts, get_acts_pca
 from task import activation_patching
 
 
-device = "cuda:4"
+device = "cuda:4" if torch.cuda.is_available() else "cpu"
 #
 # %%
 


### PR DESCRIPTION
Also allow passing `--device cpu`, `--device mps`, etc to `circle_probe_interventions.py`

Backwards-compatible alternative to #11 
Closes #11