### PR TITLE
Use dynamic device count instead of hardcoded num_devices=2

### DIFF
--- a/sae_multid_feature_discovery/generate_feature_occurence_data.py
+++ b/sae_multid_feature_discovery/generate_feature_occurence_data.py
@@ -32,7 +32,7 @@ if args.model_name == "mistral":
     model_name = "mistral-7b"
     batch_size = 16
     layers_to_evaluate = [8, 16, 24]
-    num_devices = 2
+    num_devices = max(1, t.cuda.device_count())
     sae_hidden_size = 65536
 
 else:


### PR DESCRIPTION
Replace hardcoded num_devices=2 for Mistral with
max(1, t.cuda.device_count()) to support single-GPU and CPU-only machines while using all available GPUs when present.